### PR TITLE
Archive ppodq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE**: _This repository is no longer supported or updated.  As of Mar 2025 PPOD's Cybercom Celery task has been removed from CTA Production servers.  ProQuest is no longer providing an API to submit single print orders._
+
 ppodq Queue
 ======================
 


### PR DESCRIPTION
PPODQ is no longer needed since ProQuest has removed it's API service to order printed material.